### PR TITLE
Smart contract auto generated docs

### DIFF
--- a/06-blockchain/02-contracts.md
+++ b/06-blockchain/02-contracts.md
@@ -1,0 +1,1 @@
+## NeoFS Smart Contracts

--- a/06-blockchain/03-alphabet.md
+++ b/06-blockchain/03-alphabet.md
@@ -1,0 +1,85 @@
+### alphabet contract
+
+Alphabet contract is a contract deployed in NeoFS side chain\.
+
+Alphabet contract is designed to support GAS producing and voting for new validators in the side chain\. NEO token is required to produce GAS and vote for a new committee\. If can be distributed among alphabet nodes of Inner Ring\. However\, some of them may be malicious and some NEO can be lost\. It will lead to side chain economic destabilization\. To avoid it\, all 100 000 000 NEO are distributed among all alphabet contracts\.
+
+To identify alphabet contracts\, they are named with letters of the Glagolitic\. Names are set at contract deploy\. Alphabet nodes of Inner Ring communicate with one of the alphabetical contracts to emit GAS\. To vote for a new list of side chain committee\, alphabet nodes of Inner Ring create multisignature transactions for each alphabet contract\.
+
+#### Contract notifications
+
+Alphabet contract does not produce notifications to process\.
+
+#### Contract methods
+
+##### Emit
+
+```go
+func Emit()
+```
+
+Emit method produces side chain GAS and distributes it among Inner Ring nodes and proxy contract\. Can be invoked only by Alphabet node of the Inner Ring\.
+
+To produce GAS\, alphabet contract transfers all available NEO from contract account to itself\. If notary enabled\, then 50% of the GAS in the contract account transferred to proxy contract\. 43\.75% of the GAS are equally distributed among all Inner Ring nodes\. Remaining 6\.25% of the GAS stays in the contract\.
+
+If notary disabled\, then 87\.5% of the GAS are equally distributed among all Inner Ring nodes\. Remaining 12\.5% of the GAS stays in the contract\.
+
+##### Gas
+
+```go
+func Gas() int
+```
+
+GAS returns amount of side chain GAS stored in contract account\.
+
+##### Migrate
+
+```go
+func Migrate(script []byte, manifest []byte, data interface{}) bool
+```
+
+Migrate method updates contract source code and manifest\. Can be invoked only by contract owner\.
+
+##### Name
+
+```go
+func Name() string
+```
+
+Name returns Glagolitic name of the contract\.
+
+##### Neo
+
+```go
+func Neo() int
+```
+
+NEO returns amount of side chain NEO stored in contract account\.
+
+##### OnNEP17Payment
+
+```go
+func OnNEP17Payment(from interop.Hash160, amount int, data interface{})
+```
+
+OnNEP17Payment is a callback for NEP\-17 compatible native GAS and NEO contracts\.
+
+##### Version
+
+```go
+func Version() int
+```
+
+Version returns version of the contract\.
+
+##### Vote
+
+```go
+func Vote(epoch int, candidates []interop.PublicKey)
+```
+
+Vote method votes for side chain committee\. Requires multisignature from Alphabet nodes of the Inner Ring\.
+
+This method is used when governance changes list of Alphabet nodes of the Inner Ring\. Alphabet nodes share keys with side chain validators\, therefore it is required to change them as well\. To do that NEO holders\, which are alphabet contracts\, should vote for new committee\.
+
+

--- a/06-blockchain/03-audit.md
+++ b/06-blockchain/03-audit.md
@@ -1,0 +1,83 @@
+### audit contract
+
+Audit contract is a contract deployed in NeoFS side chain\.
+
+Inner Ring nodes perform an audit of the registered containers in every epoch\. If container contains StorageGroup objects\, then the Inner Ring node initializes a series of audit checks\. Based on the results of these checks\, the Inner Ring node creates a DataAuditResult structure for the container\. The content of this structure makes it possible to determine which storage nodes were examined and the status of these checks\. Based on this information\, container owner is charged for data storage\.
+
+Audit contract is used as reliable and verifiable storage for all DataAuditResult structures\. At the end of the data audit routine\, the Inner Ring nodes send a stable marshaled version of the DataAuditResult structure to the contract\. When Alphabet nodes of the Inner Ring perform settlement operations\, they list and get these AuditResultStructures from the audit contract\.
+
+#### Contract notifications
+
+Alphabet contract does not produce notifications to process\.
+
+#### Contract methods
+
+##### Get
+
+```go
+func Get(id []byte) []byte
+```
+
+Get method returns stable marshaled DataAuditResult structure\.
+
+ID of the DataAuditResult can be obtained from listing methods\.
+
+##### List
+
+```go
+func List() [][]byte
+```
+
+List method returns list of all available DataAuditResult IDs from contract storage\.
+
+##### ListByCID
+
+```go
+func ListByCID(epoch int, cid []byte) [][]byte
+```
+
+ListByCID method returns list of DataAuditResult IDs generated in specified epoch for specified container\.
+
+##### ListByEpoch
+
+```go
+func ListByEpoch(epoch int) [][]byte
+```
+
+ListByEpoch method returns list of DataAuditResult IDs generated in specified epoch\.
+
+##### ListByNode
+
+```go
+func ListByNode(epoch int, cid []byte, key interop.PublicKey) [][]byte
+```
+
+ListByNode method returns list of DataAuditResult IDs generated in specified epoch for specified container by specified Inner Ring node\.
+
+##### Migrate
+
+```go
+func Migrate(script []byte, manifest []byte, data interface{}) bool
+```
+
+Migrate method updates contract source code and manifest\. Can be invoked only by contract owner\.
+
+##### Put
+
+```go
+func Put(rawAuditResult []byte)
+```
+
+Put method stores stable marshalled \`DataAuditResult\` structure\. Can be invoked only by Inner Ring nodes\.
+
+Inner Ring nodes perform audit of the containers and produce \`DataAuditResult\` structures\. They are being stored in audit contract and used for settlements in later epochs\.
+
+##### Version
+
+```go
+func Version() int
+```
+
+Version returns version of the contract\.
+
+

--- a/06-blockchain/03-balance.md
+++ b/06-blockchain/03-balance.md
@@ -1,0 +1,193 @@
+### balance contract
+
+Balance contract is a contract deployed in NeoFS side chain\.
+
+Balance contract stores all NeoFS account balances\. It is NEP\-17 compatible contract so in can be tracked and controlled by N3 compatible network monitors and wallet software\.
+
+This contract is used to store all micro transactions in the sidechain\, such as data audit settlements or container fee payments\. It is inefficient to make such small payment transactions in main chain\. To process small transfers\, balance contract has higher \(12\) decimal precision than native GAS contract\.
+
+NeoFS balances are synchronized with main chain operations\. Deposit produce minting of NEOFS tokens in Balance contract\. Withdraw locks some NEOFS tokens in special lock account\. When NeoFS contract transfers GAS assets back to the user\, lock account is destroyed with burn operation\.
+
+#### Contract notifications
+
+Transfer notification\. This is NEP\-17 standard notification\.
+
+```
+Transfer:
+  - name: from
+    type: Hash160
+  - name: to
+    type: Hash160
+  - name: amount
+    type: Integer
+```
+
+TransferX notification\. This is enhanced transfer notification with details\.
+
+```
+TransferX:
+  - name: from
+    type: Hash160
+  - name: to
+    type: Hash160
+  - name: amount
+    type: Integer
+  - name: details
+    type: ByteArray
+```
+
+Lock notification\. This notification is produced when Lock account has been created\. It contains information about main chain transaction that produced asset lock\, address of lock account and NeoFS epoch number until lock account is valid\. Alphabet nodes of the Inner Ring catch notification and initialize Cheque method invocation of the NeoFS contract\.
+
+```
+Lock:
+  - name: txID
+    type: ByteArray
+  - name: from
+    type: Hash160
+  - name: to
+    type: Hash160
+  - name: amount
+    type: Integer
+  - name: until
+    type: Integer
+```
+
+Mint notification\. This notification is produced when user balance is replenished from deposit in the main chain\.
+
+```
+Mint:
+ - name: to
+   type: Hash160
+ - name: amount
+   type: Integer
+```
+
+Burn notification\. This notification is produced after user balance is reduced when NeoFS contract transferred GAS assets back to the user\.
+
+```
+Burn:
+  - name: from
+    type: Hash160
+  - name: amount
+    type: Integer
+```
+
+#### Contract methods
+
+##### BalanceOf
+
+```go
+func BalanceOf(account interop.Hash160) int
+```
+
+BalanceOf is a NEP\-17 standard method that returns NeoFS balance of specified account\.
+
+##### Burn
+
+```go
+func Burn(from interop.Hash160, amount int, txDetails []byte)
+```
+
+Burn is a method that transfers assets from user account to empty account\. Can be invoked only by Alphabet nodes of the Inner Ring\.
+
+Produces Burn\, Transfer and TransferX notifications\.
+
+Burn method invoked by Alphabet nodes of the Inner Ring when they process Cheque notification from NeoFS contract\. It means that locked assets were transferred to user in main chain\, therefore lock account should be destroyed\. Before that Alphabet nodes should synchronize precision of main chain GAS contract and Balance contract\. Burn decreases total supply of NEP\-17 compatible NeoFS token\.
+
+##### Decimals
+
+```go
+func Decimals() int
+```
+
+Decimals is a NEP\-17 standard method that returns precision of NeoFS balances\.
+
+##### Lock
+
+```go
+func Lock(txDetails []byte, from, to interop.Hash160, amount, until int)
+```
+
+Lock is a method that transfers assets from user account to lock account related to the user\. Can be invoked only by Alphabet nodes of the Inner Ring\.
+
+Produces Lock\, Transfer and TransferX notifications\.
+
+Lock method invoked by Alphabet nodes of the Inner Ring when they process Withdraw notification from NeoFS contract\. This should transfer assets to new lock account that won't be used for anything besides Unlock and Burn\.
+
+##### Migrate
+
+```go
+func Migrate(script []byte, manifest []byte, data interface{}) bool
+```
+
+Migrate method updates contract source code and manifest\. Can be invoked only by contract owner\.
+
+##### Mint
+
+```go
+func Mint(to interop.Hash160, amount int, txDetails []byte)
+```
+
+Mint is a method that transfers assets to user account from empty account\. Can be invoked only by Alphabet nodes of the Inner Ring\.
+
+Produces Mint\, Transfer and TransferX notifications\.
+
+Mint method invoked by Alphabet nodes of the Inner Ring when they process Deposit notification from NeoFS contract\. Before that Alphabet nodes should synchronize precision of main chain GAS contract and Balance contract\. Mint increases total supply of NEP\-17 compatible NeoFS token\.
+
+##### NewEpoch
+
+```go
+func NewEpoch(epochNum int)
+```
+
+NewEpoch is a method that checks timeout on lock accounts and return assets if lock is not available anymore\. Can be invoked only by NewEpoch method of Netmap contract\.
+
+Produces Transfer and TransferX notifications\.
+
+##### Symbol
+
+```go
+func Symbol() string
+```
+
+Symbol is a NEP\-17 standard method that returns NEOFS token symbol\.
+
+##### TotalSupply
+
+```go
+func TotalSupply() int
+```
+
+TotalSupply is a NEP\-17 standard method that returns total amount of main chain GAS in the NeoFS network\.
+
+##### Transfer
+
+```go
+func Transfer(from, to interop.Hash160, amount int, data interface{}) bool
+```
+
+Transfer is a NEP\-17 standard method that transfers NeoFS balance from one account to other\. Can be invoked only by account owner\.
+
+Produces Transfer and TransferX notifications\. TransferX notification will have empty details field\.
+
+##### TransferX
+
+```go
+func TransferX(from, to interop.Hash160, amount int, details []byte)
+```
+
+TransferX is a method for NeoFS balance transfers from one account to another\. Can be invoked by account owner or by Alphabet nodes\.
+
+Produces Transfer and TransferX notifications\.
+
+TransferX method expands Transfer method by having extra details argument\. Also TransferX method allows to transfer assets by Alphabet nodes of the Inner Ring with multi signature\.
+
+##### Version
+
+```go
+func Version() int
+```
+
+Version returns version of the contract\.
+
+

--- a/06-blockchain/03-container.md
+++ b/06-blockchain/03-container.md
@@ -1,0 +1,169 @@
+### container contract
+
+Container contract is a contract deployed in NeoFS side chain\.
+
+Container contract stores and manages containers\, extended ACLs and container size estimations\. Contract does not perform sanity or signature checks of the containers or extended ACLs\, it is done by Alphabet nodes of the Inner Ring\. Alphabet nodes approve it by invoking the same Put or SetEACL methods with the same arguments\.
+
+#### Contract notifications
+
+containerPut notification\. This notification is produced when user wants to create new container\. Alphabet nodes of the Inner Ring catch notification and validate container data\, signature and token if it is present\.
+
+```
+containerPut:
+  - name: container
+    type: ByteArray
+  - name: signature
+    type: Signature
+  - name: publicKey
+    type: PublicKey
+  - name: token
+    type: ByteArray
+```
+
+containerDelete notification\. This notification is produced when container owner wants to delete container\. Alphabet nodes of the Inner Ring catch notification and validate container ownership\, signature and token if it is present\.
+
+```
+containerDelete:
+  - name: containerID
+    type: ByteArray
+  - name: signature
+    type: Signature
+  - name: token
+    type: ByteArray
+```
+
+setEACL notification\. This notification is produced when container owner wants to update extended ACL of the container\. Alphabet nodes of the Inner Ring catch notification and validate container ownership\, signature and token if it is present\.
+
+```
+setEACL:
+  - name: eACL
+    type: ByteArray
+  - name: signature
+    type: Signature
+  - name: publicKey
+    type: PublicKey
+  - name: token
+    type: ByteArray
+```
+
+StartEstimation notification\. This notification is produced when Storage nodes should exchange estimation values of container sizes among other Storage nodes\.
+
+```
+StartEstimation:
+  - name: epoch
+    type: Integer
+```
+
+StopEstimation notification\. This notification is produced when Storage nodes should calculate average container size based on received estimations and store it in Container contract\.
+
+```
+StopEstimation:
+  - name: epoch
+    type: Integer
+```
+
+#### Contract methods
+
+##### Delete
+
+```go
+func Delete(containerID []byte, signature interop.Signature, token []byte)
+```
+
+Delete method removes container from contract storage if it was invoked by Alphabet nodes of the Inner Ring\. Otherwise it produces containerDelete notification\.
+
+Signature is a RFC6979 signature of container ID\. Token is optional and should be stable marshaled SessionToken structure from API\.
+
+##### List
+
+```go
+func List(owner []byte) [][]byte
+```
+
+List method returns list of all container IDs owned by specified owner\.
+
+##### ListContainerSizes
+
+```go
+func ListContainerSizes(epoch int) [][]byte
+```
+
+ListContainerSizes method returns IDs of container size estimations that has been registered for specified epoch\.
+
+##### Migrate
+
+```go
+func Migrate(script []byte, manifest []byte, data interface{}) bool
+```
+
+Migrate method updates contract source code and manifest\. Can be invoked only by contract owner\.
+
+##### NewEpoch
+
+```go
+func NewEpoch(epochNum int)
+```
+
+NewEpoch method removes all container size estimations from epoch older than epochNum \+ 3\. Can be invoked only by NewEpoch method of the Netmap contract\.
+
+##### Owner
+
+```go
+func Owner(containerID []byte) []byte
+```
+
+Owner method returns 25 byte Owner ID of the container\.
+
+##### Put
+
+```go
+func Put(container []byte, signature interop.Signature, publicKey interop.PublicKey, token []byte)
+```
+
+Put method creates new container if it was invoked by Alphabet nodes of the Inner Ring\. Otherwise it produces containerPut notification\.
+
+Container should be stable marshaled Container structure from API\. Signature is a RFC6979 signature of Container\. PublicKey contains public key of the signer\. Token is optional and should be stable marshaled SessionToken structure from API\.
+
+##### PutContainerSize
+
+```go
+func PutContainerSize(epoch int, cid []byte, usedSize int, pubKey interop.PublicKey)
+```
+
+PutContainerSize method saves container size estimation in contract memory\. Can be invoked only by Storage nodes from the network map\. Method checks witness based on the provided public key of the Storage node\.
+
+##### SetEACL
+
+```go
+func SetEACL(eACL []byte, signature interop.Signature, publicKey interop.PublicKey, token []byte)
+```
+
+SetEACL method sets new extended ACL table related to the contract if it was invoked by Alphabet nodes of the Inner Ring\. Otherwise it produces setEACL notification\.
+
+EACL should be stable marshaled EACLTable structure from API\. Signature is a RFC6979 signature of Container\. PublicKey contains public key of the signer\. Token is optional and should be stable marshaled SessionToken structure from API\.
+
+##### StartContainerEstimation
+
+```go
+func StartContainerEstimation(epoch int)
+```
+
+StartContainerEstimation method produces StartEstimation notification\. Can be invoked only by Alphabet nodes of the Inner Ring\.
+
+##### StopContainerEstimation
+
+```go
+func StopContainerEstimation(epoch int)
+```
+
+StopContainerEstimation method produces StopEstimation notification\. Can be invoked only by Alphabet nodes of the Inner Ring\.
+
+##### Version
+
+```go
+func Version() int
+```
+
+Version returns version of the contract\.
+
+

--- a/06-blockchain/03-neofs.md
+++ b/06-blockchain/03-neofs.md
@@ -1,0 +1,241 @@
+### neofs contract
+
+NeoFS contract is a contract deployed in NeoFS main chain\.
+
+NeoFS contract is an entry point to NeoFS users\. This contract stores all NeoFS related GAS\, registers new Inner Ring candidates and produces notifications to control side chain\.
+
+While main chain committee controls list of Alphabet nodes in native RoleManagement contract\, NeoFS can't change more than 1\\3 keys at a time\. NeoFS contract contains actual list of Alphabet nodes in the side chain\.
+
+Network configuration also stored in NeoFS contract\. All the changes in configuration are mirrored in side chain with notifications\.
+
+#### Contract notifications
+
+Deposit notification\. This notification is produced when user transfers native GAS to the NeoFS contract address\. The same amount of NEOFS token will be minted in Balance contract in the side chain\.
+
+```
+Deposit:
+  - name: from
+    type: Hash160
+  - name: amount
+    type: Integer
+  - name: receiver
+    type: Hash160
+  - name: txHash
+    type: Hash256
+```
+
+Withdraw notification\. This notification is produced when user wants to withdraw GAS from internal NeoFS balance and has payed fee for that\.
+
+```
+Withdraw:
+  - name: user
+    type: Hash160
+  - name: amount
+    type: Integer
+  - name: txHash
+    type: Hash256
+```
+
+Cheque notification\. This notification is produced when NeoFS contract successfully transferred assets back to the user after withdraw\.
+
+```
+Cheque:
+  - name: id
+    type: ByteArray
+  - name: user
+    type: Hash160
+  - name: amount
+    type: Integer
+  - name: lockAccount
+    type: ByteArray
+```
+
+Bind notification\. This notification is produced when user wants to bind public keys with user account \(OwnerID\)\. Keys argument is array of ByteArray\.
+
+```
+Bind:
+  - name: user
+    type: ByteArray
+  - name: keys
+    type: Array
+```
+
+Unbind notification\. This notification is produced when user wants to unbind public keys with user account \(OwnerID\)\. Keys argument is an array of ByteArray\.
+
+```
+Unbind:
+  - name: user
+    type: ByteArray
+  - name: keys
+    type: Array
+```
+
+AlphabetUpdate notification\. This notification is produced when Alphabet nodes updated it's list in the contract\. Alphabet argument is an array of ByteArray\. It contains public keys of new alphabet nodes\.
+
+```
+AlphabetUpdate:
+  - name: id
+    type: ByteArray
+  - name: alphabet
+    type: Array
+```
+
+SetConfig notification\. This notification is produced when Alphabet nodes update NeoFS network configuration value\.
+
+```
+SetConfig
+  - name: id
+    type: ByteArray
+  - name: key
+    type: ByteArray
+  - name: value
+    type: ByteArray
+```
+
+#### Contract methods
+
+##### AlphabetAddress
+
+```go
+func AlphabetAddress() interop.Hash160
+```
+
+AlphabetAddress returns 2\\3n\+1 multi signature address of alphabet nodes\. Used in side chain notary disabled environment\.
+
+##### AlphabetList
+
+```go
+func AlphabetList() []common.IRNode
+```
+
+AlphabetList returns array of alphabet node keys\. Use in side chain notary disabled environment\.
+
+##### AlphabetUpdate
+
+```go
+func AlphabetUpdate(id []byte, args []interop.PublicKey)
+```
+
+AlphabetUpdate updates list of alphabet nodes with provided list of public keys\. Can be invoked only by alphabet nodes\.
+
+This method used in notary disabled side chain environment\. In this case actual alphabet list should be stored in the NeoFS contract\.
+
+##### Bind
+
+```go
+func Bind(user []byte, keys []interop.PublicKey)
+```
+
+Bind method produces notification to bind specified public keys in NeoFSID contract in side chain\. Can be invoked only by specified user\.
+
+This method produces Bind notification\. Method panics if keys are not 33 byte long\. User argument must be valid 20 byte script hash\.
+
+##### Cheque
+
+```go
+func Cheque(id []byte, user interop.Hash160, amount int, lockAcc []byte)
+```
+
+Cheque transfers GAS back to the user from contract account\, if assets were successfully locked in NeoFS balance contract\. Can be invoked only by Alphabet nodes\.
+
+This method produces Cheque notification to burn assets in side chain\.
+
+##### Config
+
+```go
+func Config(key []byte) interface{}
+```
+
+Config returns configuration value of NeoFS configuration\. If key does not exists\, returns nil\.
+
+##### InitConfig
+
+```go
+func InitConfig(args [][]byte)
+```
+
+InitConfig method sets up initial key\-value configuration pair\. Can be invoked only once\.
+
+Arguments should contain even number of byte arrays\. First byte array is a configuration key and the second is configuration value\.
+
+##### InnerRingCandidateAdd
+
+```go
+func InnerRingCandidateAdd(key interop.PublicKey)
+```
+
+InnerRingCandidateAdd adds key to the list of Inner Ring candidates\. Can be invoked only by candidate itself\.
+
+This method transfers fee from candidate to contract account\. Fee value specified in NeoFS network config with the key InnerRingCandidateFee\.
+
+##### InnerRingCandidateRemove
+
+```go
+func InnerRingCandidateRemove(key interop.PublicKey)
+```
+
+InnerRingCandidateRemove removes key from the list of Inner Ring candidates\. Can be invoked by Alphabet nodes or candidate itself\.
+
+Method does not return fee back to the candidate\.
+
+##### InnerRingCandidates
+
+```go
+func InnerRingCandidates() []common.IRNode
+```
+
+InnerRingCandidates returns array of structures that contain Inner Ring candidate node key\.
+
+##### Migrate
+
+```go
+func Migrate(script []byte, manifest []byte, data interface{}) bool
+```
+
+Migrate method updates contract source code and manifest\. Can be invoked only by contract owner\.
+
+##### OnNEP17Payment
+
+```go
+func OnNEP17Payment(from interop.Hash160, amount int, data interface{})
+```
+
+OnNEP17Payment is a callback for NEP\-17 compatible native GAS contract\. It takes no more than 9000\.0 GAS\. Native GAS has precision 8 and NeoFS balance contract has precision 12\. Values bigger than 9000\.0 can break JSON limits for integers when precision is converted\.
+
+##### SetConfig
+
+```go
+func SetConfig(id, key, val []byte)
+```
+
+SetConfig key\-value pair as a NeoFS runtime configuration value\. Can be invoked only by Alphabet nodes\.
+
+##### Unbind
+
+```go
+func Unbind(user []byte, keys []interop.PublicKey)
+```
+
+Unbind method produces notification to unbind specified public keys in NeoFSID contract in side chain\. Can be invoked only by specified user\.
+
+This method produces Unbind notification\. Method panics if keys are not 33 byte long\. User argument must be valid 20 byte script hash\.
+
+##### Version
+
+```go
+func Version() int
+```
+
+Version returns version of the contract\.
+
+##### Withdraw
+
+```go
+func Withdraw(user interop.Hash160, amount int)
+```
+
+Withdraw initialize gas asset withdraw from NeoFS\. Can be invoked only by the specified user\.
+
+This method produces Withdraw notification to lock assets in side chain and transfers withdraw fee from user account to each Alphabet node\. If notary is enabled in main chain\, fee is transferred to Processing contract\. Fee value specified in NeoFS network config with the key WithdrawFee\.
+
+

--- a/06-blockchain/03-neofsid.md
+++ b/06-blockchain/03-neofsid.md
@@ -1,0 +1,61 @@
+### neofsid contract
+
+NeoFSID contract is a contract deployed in NeoFS side chain\.
+
+NeoFSID contract used to store connection between OwnerID and it's public keys\. OwnerID is a 25\-byte N3 wallet address that can be produced from public key\. It is one\-way conversion\. In simple cases NeoFS verifies ownership by checking signature and relation between public key and OwnerID\.
+
+In more complex cases\, user can use public keys unrelated to OwnerID to maintain secure access to the data\. NeoFSID contract stores relation between OwnerID and arbitrary public keys\. Data owner can bind or unbind public key with it's account by invoking Bind or Unbind methods of NeoFS contract in main chain\. After that\, Alphabet nodes produce multi signed AddKey and RemoveKey invocations of NeoFSID contract\.
+
+#### Contract notifications
+
+NeoFSID contract does not produce notifications to process\.
+
+#### Contract methods
+
+##### AddKey
+
+```go
+func AddKey(owner []byte, keys []interop.PublicKey)
+```
+
+AddKey binds list of provided public keys to OwnerID\. Can be invoked only by Alphabet nodes\.
+
+This method panics if OwnerID is not 25 byte or public key is not 33 byte long\. If key is already bound\, ignores it\.
+
+##### Key
+
+```go
+func Key(owner []byte) [][]byte
+```
+
+Key method returns list of 33\-byte public keys bound with OwnerID\.
+
+This method panics if owner is not 25 byte long\.
+
+##### Migrate
+
+```go
+func Migrate(script []byte, manifest []byte, data interface{}) bool
+```
+
+Migrate method updates contract source code and manifest\. Can be invoked only by contract owner\.
+
+##### RemoveKey
+
+```go
+func RemoveKey(owner []byte, keys []interop.PublicKey)
+```
+
+RemoveKey unbinds provided public keys from OwnerID\. Can be invoked only by Alphabet nodes\.
+
+This method panics if OwnerID is not 25 byte or public key is not 33 byte long\. If key is already unbound\, ignores it\.
+
+##### Version
+
+```go
+func Version() int
+```
+
+Version returns version of the contract\.
+
+

--- a/06-blockchain/03-netmap.md
+++ b/06-blockchain/03-netmap.md
@@ -1,0 +1,149 @@
+### netmap contract
+
+Netmap contract is a contract deployed in NeoFS side chain\.
+
+Netmap contract stores and manages NeoFS network map\, Storage node candidates and epoch number counter\. In notary disabled environment\, contract also stores list of Inner Ring node keys\.
+
+#### Contract notifications
+
+AddPeer notification\. This notification is produced when Storage node sends bootstrap request by invoking AddPeer method\.
+
+```
+AddPeer
+  - name: nodeInfo
+    type: ByteArray
+```
+
+UpdateState notification\. This notification is produced when Storage node wants to change it's state \(go offline\) by invoking UpdateState method\. Supported states: \(2\) \-\- offline\.
+
+```
+UpdateState
+  - name: state
+    type: Integer
+  - name: publicKey
+    type: PublicKey
+```
+
+NewEpoch notification\. This notification is produced when new epoch is applied in the network by invoking NewEpoch method\.
+
+```
+NewEpoch
+  - name: epoch
+    type: Integer
+```
+
+#### Contract methods
+
+##### AddPeer
+
+```go
+func AddPeer(nodeInfo []byte)
+```
+
+AddPeer method adds new candidate to the next network map if it was invoked by Alphabet node\. If it was invoked by node candidate\, it produces AddPeer notification\. Otherwise method throws panic\.
+
+NodeInfo argument contains stable marshaled version of netmap\.NodeInfo structure\.
+
+##### Config
+
+```go
+func Config(key []byte) interface{}
+```
+
+Config returns configuration value of NeoFS configuration\. If key does not exists\, returns nil\.
+
+##### Epoch
+
+```go
+func Epoch() int
+```
+
+Epoch method returns current epoch number\.
+
+##### InitConfig
+
+```go
+func InitConfig(args [][]byte)
+```
+
+InitConfig method sets up initial key\-value configuration pair\. Can be invoked only once\.
+
+Arguments should contain even number of byte arrays\. First byte array is a configuration key and the second is configuration value\.
+
+##### InnerRingList
+
+```go
+func InnerRingList() []common.IRNode
+```
+
+InnerRingList method returns slice of structures that contains public key of Inner Ring node\. Should be used only in notary disabled environment\.
+
+If notary enabled\, then look to NeoFSAlphabet role in native RoleManagement contract of the side chain\.
+
+##### LastEpochBlock
+
+```go
+func LastEpochBlock() int
+```
+
+LastEpochBlock method returns block number when current epoch was applied\.
+
+##### Migrate
+
+```go
+func Migrate(script []byte, manifest []byte, data interface{}) bool
+```
+
+Migrate method updates contract source code and manifest\. Can be invoked only by contract owner\.
+
+##### NewEpoch
+
+```go
+func NewEpoch(epochNum int)
+```
+
+NewEpoch method changes epoch number up to provided epochNum argument\. Can be invoked only by Alphabet nodes\. If provided epoch number is less or equal current epoch number\, method throws panic\.
+
+When epoch number updated\, contract sets storage node candidates as current network map\. Also contract invokes NewEpoch method on Balance and Container contracts\.
+
+Produces NewEpoch notification\.
+
+##### SetConfig
+
+```go
+func SetConfig(id, key, val []byte)
+```
+
+SetConfig key\-value pair as a NeoFS runtime configuration value\. Can be invoked only by Alphabet nodes\.
+
+##### UpdateInnerRing
+
+```go
+func UpdateInnerRing(keys []interop.PublicKey)
+```
+
+UpdateInnerRing method updates list of Inner Ring node keys\. Should be used only in notary disabled environment\. Can be invoked only by Alphabet nodes\.
+
+If notary enabled\, then update NeoFSAlphabet role in native RoleManagement contract of the side chain\. Use notary service to collect multi signature\.
+
+##### UpdateState
+
+```go
+func UpdateState(state int, publicKey interop.PublicKey)
+```
+
+UpdateState method updates state of node from the network map candidate list if it was invoked by Alphabet node\. If it was invoked by public key owner\, then it produces UpdateState notification\. Otherwise method throws panic\.
+
+State argument defines node state\. The only supported state now is \(2\) \-\- offline state\. Node is removed from network map candidate list\.
+
+Method panics when invoked with unsupported states\.
+
+##### Version
+
+```go
+func Version() int
+```
+
+Version returns version of the contract\.
+
+

--- a/06-blockchain/03-processing.md
+++ b/06-blockchain/03-processing.md
@@ -1,0 +1,47 @@
+### processing contract
+
+Processing contract is a contract deployed in NeoFS main chain\.
+
+Processing contract pays for all multi signature transaction executions when notary service enabled in main chain\. Notary service prepares multi signed transaction\, however they should contain side chain GAS to be executed\. It is inconvenient to ask Alphabet nodes to pay for these transactions: nodes can change over time\, some nodes will spend side chain GAS faster\, it creates economic instability\.
+
+Processing contract exists to solve this issue\. At the Withdraw invocation of NeoFS contract\, user pays fee directly to this contract\. This fee is used to pay for Cheque invocation of NeoFS contract that returns main chain GAS back to the user\. Address of the Processing contract is uses as the first signer in the multi signature transaction\. Therefore NeoVM executes Verify method of the contract and if invocation is verified\, then Processing contract pays for the execution\.
+
+#### Contract notifications
+
+Processing contract does not produce notifications to process\.
+
+#### Contract methods
+
+##### Migrate
+
+```go
+func Migrate(script []byte, manifest []byte, data interface{}) bool
+```
+
+Migrate method updates contract source code and manifest\. Can be invoked only by contract owner\.
+
+##### OnNEP17Payment
+
+```go
+func OnNEP17Payment(from interop.Hash160, amount int, data interface{})
+```
+
+OnNEP17Payment is a callback for NEP\-17 compatible native GAS contract\.
+
+##### Verify
+
+```go
+func Verify() bool
+```
+
+Verify method returns true if transaction contains valid multi signature of Alphabet nodes of the Inner Ring\.
+
+##### Version
+
+```go
+func Version() int
+```
+
+Version returns version of the contract\.
+
+

--- a/06-blockchain/03-proxy.md
+++ b/06-blockchain/03-proxy.md
@@ -1,0 +1,47 @@
+### proxy contract
+
+Proxy contract is a contract deployed in NeoFS side chain\.
+
+Proxy contract pays for all multi signature transaction executions when notary service enabled in side chain\. Notary service prepares multi signed transaction\, however they should contain side chain GAS to be executed\. It is inconvenient to ask Alphabet nodes to pay for these transactions: nodes can change over time\, some nodes will spend side chain GAS faster\, it creates economic instability\.
+
+Proxy contract exists to solve this issue\. While Alphabet contracts hold all side chain NEO\, proxy contract holds most of the side chain GAS\. Alphabet contracts emits half of the available GAS to the proxy contract\. Address of the Proxy contract is used as the first signer in the multi signature transaction\. Therefore NeoVM executes Verify method of the contract and if invocation is verified\, then Proxy contract pays for the execution\.
+
+#### Contract notifications
+
+Proxy contract does not produce notifications to process\.
+
+#### Contract methods
+
+##### Migrate
+
+```go
+func Migrate(script []byte, manifest []byte, data interface{}) bool
+```
+
+Migrate method updates contract source code and manifest\. Can be invoked only by contract owner\.
+
+##### OnNEP17Payment
+
+```go
+func OnNEP17Payment(from interop.Hash160, amount int, data interface{})
+```
+
+OnNEP17Payment is a callback for NEP\-17 compatible native GAS contract\.
+
+##### Verify
+
+```go
+func Verify() bool
+```
+
+Verify method returns true if transaction contains valid multi signature of Alphabet nodes of the Inner Ring\.
+
+##### Version
+
+```go
+func Version() int
+```
+
+Version returns version of the contract\.
+
+

--- a/06-blockchain/03-reputation.md
+++ b/06-blockchain/03-reputation.md
@@ -1,0 +1,65 @@
+### reputation contract
+
+Reputation contract is a contract deployed in NeoFS side chain\.
+
+Inner Ring nodes produce data audit for each container in each epoch\. In the end nodes produce DataAuditResult structure that contains information about audit progress\. Reputation contract provides storage for such structures and simple interface to iterate over available DataAuditResults on specified epoch\.
+
+During settlement process\, Alphabet nodes fetch all DataAuditResult structures from the epoch and execute balance transfers from data owners to Storage and Inner Ring nodes\, if data audit succeed\.
+
+#### Contract notifications
+
+Reputation contract does not produce notifications to process\.
+
+#### Contract methods
+
+##### Get
+
+```go
+func Get(epoch int, peerID []byte) [][]byte
+```
+
+Get method returns list of all stable marshaled DataAuditResult structures produced by specified Inner Ring node in specified epoch\.
+
+##### GetByID
+
+```go
+func GetByID(id []byte) [][]byte
+```
+
+GetByID method returns list of all stable marshaled DataAuditResult with specified id\. Use ListByEpoch method to obtain id\.
+
+##### ListByEpoch
+
+```go
+func ListByEpoch(epoch int) [][]byte
+```
+
+ListByEpoch returns list of IDs that may be used to get reputation data with GetByID method\.
+
+##### Migrate
+
+```go
+func Migrate(script []byte, manifest []byte, data interface{}) bool
+```
+
+Migrate method updates contract source code and manifest\. Can be invoked only by contract owner\.
+
+##### Put
+
+```go
+func Put(epoch int, peerID []byte, value []byte)
+```
+
+Put method saves DataAuditResult in contract storage\. Can be invoked only by Inner Ring nodes\. Does not require multi signature invocations\.
+
+Epoch is an epoch number when DataAuditResult structure was generated\. PeerID contains public keys of Inner Ring node that produced DataAuditResult\. Value contains stable marshaled structure of DataAuditResult\.
+
+##### Version
+
+```go
+func Version() int
+```
+
+Version returns version of the contract\.
+
+

--- a/06-blockchain/04-extra.md
+++ b/06-blockchain/04-extra.md
@@ -1,0 +1,19 @@
+## Balance transfer details encoding
+
+Alphabet nodes of the Inner Ring use `balance.TransferX` method to manage
+balances of the NeoFS users at deposit (mint), withdraw (burn), audit
+settlements, etc. `TransferX` method has `details` argument and `transferX`
+notification contains `details` field. This field contains bytes that encode
+reason of data transfer. First byte of the `details` field defines transfer
+type and all other bytes provide extra details.
+
+| First Byte | Description | Extra data |
+| --- | ------- | ----------- |
+|0x01|**Mint**: deposit processed by NeoFS contract.|32-byte hash of main chain transaction which invoked `neofs.Deposit` method.|
+|0x02|**Burn**: cheque processed by NeoFS contract.|32-byte hash of main chain transaction which invoked `neofs.Cheque` method.|
+|0x03|**Lock**: withdraw processed by NeoFS contract.|32-byte hash of main chain transaction which invoked `neofs.Withdraw` method.|
+|0x04|**Unlock**: withdraw processed by NeoFS contract but cheque didn't process before timeout, so balance returned to the account.|Up to 8 bytes of epoch number when asset lock was removed.|
+|0x10|**ContainerFee**: put processed by Container contract.|32-byte Container ID|
+|0x40|**AuditSettlement**: payment to Inner Ring node for processed audit.|8 bytes of epoch (LittleEndian) number when settlement happened.|
+|0x41|**BasicIncomeCollection**: transfer assets from data owner accounts to the banking account.|8 bytes of epoch (LittleEndian) number when settlement happened.|
+|0x42|**BasicIncomeDistribution**: transfer assets from banking account to storage node owner accounts.|8 bytes of epoch (LittleEndian) number when settlement happened.|

--- a/06-blockchain/11-mainnet.md
+++ b/06-blockchain/11-mainnet.md
@@ -1,3 +1,0 @@
-## N3 Main Net Contract
-
-Main Native and traditional Smart Contracts

--- a/06-blockchain/21-netmap.md
+++ b/06-blockchain/21-netmap.md
@@ -1,3 +1,0 @@
-## Network Map Contract
-
-Netmap

--- a/06-blockchain/22-neofsid.md
+++ b/06-blockchain/22-neofsid.md
@@ -1,1 +1,0 @@
-## NeoFS.ID and NeoID

--- a/06-blockchain/23-container.md
+++ b/06-blockchain/23-container.md
@@ -1,1 +1,0 @@
-## Container Contract

--- a/06-blockchain/24-balance.md
+++ b/06-blockchain/24-balance.md
@@ -1,1 +1,0 @@
-## Balance Contract

--- a/06-blockchain/25-audit.md
+++ b/06-blockchain/25-audit.md
@@ -1,1 +1,0 @@
-## Data Audit Journal Contract

--- a/06-blockchain/26-reputation.md
+++ b/06-blockchain/26-reputation.md
@@ -1,2 +1,0 @@
-## Reputation Contract
-

--- a/06-blockchain/27-voting.md
+++ b/06-blockchain/27-voting.md
@@ -1,1 +1,0 @@
-## Voting Contract

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ OUT_DIR = output
 APIV2_DIR = "../neofs-api"
 APIV2_DOC_DIR = "20-api-v2"
 
+CONTRACTS_DIR = "../neofs-contract"
+CONTRACTS = $(shell echo "${CONTRACTS_DIR}/alphabet")
+CONTRACTS_DOC_DIR = "06-blockchain"
+
 PDF_NAME?= "neofs-spec-${VERSION}.pdf"
 TEX_NAME?= "neofs-spec-${VERSION}.tex"
 PARTS = $(shell find . -mindepth 2 -maxdepth 2 -type f -name '*.md' | sort)
@@ -105,6 +109,20 @@ update_api_v2:
 	done
 
 update_api: update_api_v2
+
+.PHONY: update_contracts
+
+.ONESHELL:
+update_contracts:
+	@for f in `find ${CONTRACTS_DIR} -mindepth 2 -maxdepth 2 -type f ! -path '*/nns/*' -name '*_contract.go'  -exec dirname {} \; | sort -u `;
+	do
+		echo "Documentation for $$(basename $$f)";
+		gomarkdoc --template-file file=templates/contracts-file.tmpl \
+			--template-file package=templates/contracts-package.tmpl \
+			--template-file func=templates/contracts-func.tmpl \
+			--template-file doc=templates/contracts-doc.tmpl \
+			$$f > ${CONTRACTS_DOC_DIR}/03-$$(basename $$f).md
+	done
 
 .PHONY: image docker_build
 

--- a/templates/contracts-doc.tmpl
+++ b/templates/contracts-doc.tmpl
@@ -1,0 +1,9 @@
+{{- range .Blocks -}}
+	{{- if eq .Kind "paragraph" -}}
+		{{- paragraph .Text  -}}
+	{{- else if eq .Kind "code" -}}
+		{{- codeBlock "" .Text -}}
+	{{- else if eq .Kind "header" -}}
+		{{- header (add .Level 1) .Text -}}
+	{{- end -}}
+{{- end -}}

--- a/templates/contracts-file.tmpl
+++ b/templates/contracts-file.tmpl
@@ -1,0 +1,7 @@
+{{.Header -}}
+
+{{- range .Packages -}}
+	{{- template "package" . -}}
+{{- end -}}
+
+{{- .Footer}}

--- a/templates/contracts-func.tmpl
+++ b/templates/contracts-func.tmpl
@@ -1,0 +1,9 @@
+{{- .Name | rawHeader (add .Level 3) -}}
+
+{{- codeBlock "go" .Signature -}}
+
+{{- template "doc" .Doc -}}
+
+{{- range .Examples -}}
+	{{- template "example" . -}}
+{{- end -}}

--- a/templates/contracts-package.tmpl
+++ b/templates/contracts-package.tmpl
@@ -1,0 +1,17 @@
+{{- if eq .Name "main" -}}
+	{{- header .Level .Dirname -}}
+{{- else -}}
+	{{- .Name | printf "%s contract" | header (add .Level 2)  -}}
+{{- end -}}
+
+{{- template "doc" .Doc -}}
+
+{{- range .Examples -}}
+	{{- template "example" . -}}
+{{- end -}}
+
+{{- header (add .Level 3) "Contract methods" -}}
+
+{{- range .Funcs -}}
+	{{- template "func" . -}}
+{{- end -}}


### PR DESCRIPTION
Closes #49 

## Issues

At first I wanted to have `<xxx> contract` header to be at level 2. However I wasn't able to make contract name starting with capital letter in template, so it either should be at level 3 or be `Contract <xxx>`. I decided to go with first option.

Because of that public methods placed in level 5 headers and that may look odd in the output pdf.

## Todo

- [x] Alphabet
- [x] Audit
- [x] Balance
- [x] Container
- [x] NeoFS
- [x] NeoFSID
- [x] Netmap
- [x] Processing
- [x] Proxy
- [x] Reputation