### PR TITLE
Dockerfile: use JDK 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
   latexmk \
   libgraphviz-dev \
   make \
-  openjdk-14-jre \
+  openjdk-16-jre \
   python3-pip \
   librsvg2-bin \
   texlive-fonts-extra \


### PR DESCRIPTION
Ubuntu 20.04 just doesn't have version 14, so this image can't be built.