### PR TITLE
.github: fetch variables from the proper place

### DIFF
--- a/.github/workflows/neofs.yml
+++ b/.github/workflows/neofs.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           NEOFS_WALLET: ${{ secrets.NEOFS_WALLET }}
           NEOFS_WALLET_PASSWORD: ${{ secrets.NEOFS_WALLET_PASSWORD }}
-          NEOFS_NETWORK_DOMAIN: ${{ env.NEOFS_NETWORK_DOMAIN }}
-          NEOFS_HTTP_GATE: ${{ env.NEOFS_HTTP_GATE }}
-          STORE_OBJECTS_CID: ${{ env.STORE_OBJECTS_CID }}
+          NEOFS_NETWORK_DOMAIN: ${{ vars.NEOFS_NETWORK_DOMAIN }}
+          NEOFS_HTTP_GATE: ${{ vars.NEOFS_HTTP_GATE }}
+          STORE_OBJECTS_CID: ${{ vars.STORE_OBJECTS_CID }}
           PATH_TO_FILES_DIR: output


### PR DESCRIPTION
They're repository variables, they reside in `vars`.