### PR TITLE
workflows: update GH action to 0.3.0

### DIFF
--- a/.github/workflows/neofs.yml
+++ b/.github/workflows/neofs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Publish to NeoFS
         id: publish_spec_pdf_to_neofs
-        uses: nspcc-dev/gh-push-to-neofs@v0.1.2
+        uses: nspcc-dev/gh-push-to-neofs@v0.3.0
         with:
           NEOFS_WALLET: ${{ secrets.NEOFS_WALLET }}
           NEOFS_WALLET_PASSWORD: ${{ secrets.NEOFS_WALLET_PASSWORD }}


### PR DESCRIPTION
It has REPLACE_OBJECTS by default which should fix the fs.neo.org link to the latest documentation.