### PR TITLE
workflows: update gh-push-to-neofs to 0.5.0

### DIFF
--- a/.github/workflows/neofs.yml
+++ b/.github/workflows/neofs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Publish to NeoFS
         id: publish_spec_pdf_to_neofs
-        uses: nspcc-dev/gh-push-to-neofs@v0.4.0
+        uses: nspcc-dev/gh-push-to-neofs@v0.5.0
         with:
           NEOFS_WALLET: ${{ secrets.NEOFS_WALLET }}
           NEOFS_WALLET_PASSWORD: ${{ secrets.NEOFS_WALLET_PASSWORD }}


### PR DESCRIPTION
Fixes upload to NeoFS that fails with

    Stderr: rpc error: search objects using NeoFS API: rpc error: code = Unimplemented desc = no longer supported, use SearchV2